### PR TITLE
Remove babel-cli dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,8 +4,6 @@
   "description": "Collection of icons used at Casper",
   "main": "gulpfile.babel.js",
   "scripts": {
-    "build": "babel gulpfile.babel.js -o gulpfile.js",
-    "test": "gulp",
     "postversion": "git push && git push --tags"
   },
   "repository": {
@@ -24,7 +22,6 @@
   },
   "homepage": "https://github.com/caspersleep/nightshade-icons#readme",
   "dependencies": {
-    "babel-cli": "^6.4.5",
     "babel-preset-es2015": "^6.3.13",
     "gulp": "^3.9.0",
     "gulp-plumber": "^1.0.1",


### PR DESCRIPTION
Residual dependency that we don't need to keep. Also removes two scripts that we don't call/use.

Hoping this removal will take care of the rogue phantomjs install happening in Casper Classic repo.
